### PR TITLE
LocalStorage remove and css addCart

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "redux": "^4.1.1",
     "redux-thunk": "^2.3.0",
     "styled-components": "^5.3.1",
+    "sweetalert2": "^11.1.9",
     "web-vitals": "^1.1.2"
   },
   "scripts": {

--- a/client/src/components/AddToCart/Addtocart.jsx
+++ b/client/src/components/AddToCart/Addtocart.jsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux"
 import { addCart, removeCart, removeItem } from '../../redux/actions';
 import { Link } from "react-router-dom";
 import { useState } from 'react';
+import Swal from 'sweetalert2'
 
 export default function({ id, stock }) {
 
@@ -15,6 +16,22 @@ export default function({ id, stock }) {
     if(count < stock){
       setCount(count + 1);
       dispatch(addCart(id)) 
+      const Toast = Swal.mixin({
+        toast: true,
+        position: 'top-end',
+        showConfirmButton: false,
+        timer: 3000,
+        timerProgressBar: true,
+        didOpen: (toast) => {
+            toast.addEventListener('mouseenter', Swal.stopTimer)
+            toast.addEventListener('mouseleave', Swal.resumeTimer)
+        }
+    })
+
+    Toast.fire({
+        icon: 'success',
+        title: 'The product was added to the cart!'
+    })
     }
   }
 

--- a/client/src/components/Login/LogoutTest.jsx
+++ b/client/src/components/Login/LogoutTest.jsx
@@ -15,6 +15,7 @@ export function Logout(){
 
      useEffect(() => {
        createUser()
+       localStorage.removeItem('items')
       }, [])
     
 

--- a/client/src/components/Product/Product.jsx
+++ b/client/src/components/Product/Product.jsx
@@ -1,44 +1,70 @@
-import React from "react";
+import React, { useState } from "react";
 import './product.css';
-import { Link, NavLink } from "react-router-dom"; 
+import { Link, NavLink } from "react-router-dom";
 import Rating from '../Rating/Rating';
-import { BsFillEyeFill} from 'react-icons/bs';
-import {AiTwotoneHeart} from 'react-icons/ai'
-import { addProductFav } from "../../redux/actions";
+import { BsHeartFill } from 'react-icons/bs';
+import { FaCartPlus } from 'react-icons/fa'
+import { addCart } from '../../redux/actions';
 import { useDispatch } from "react-redux";
+import Swal from 'sweetalert2'
 
-export default function Product({ _id, img, name, price, rating, isActive }) {
-    const dispatch = useDispatch();
+export default function Product({ _id, img, name, price, rating, isActive, stock }) {
 
-    const objFav = {_id, name, img, price}
+    const [count, setCount] = useState(0);
 
-    console.log(isActive)
+    const dispatch = useDispatch()
+
+    const handleAddCart = (e) => {
+        e.preventDefault()
+        if (count < stock) {
+            setCount(count + 1);
+            dispatch(addCart(_id))
+            const Toast = Swal.mixin({
+                toast: true,
+                position: 'top-end',
+                showConfirmButton: false,
+                timer: 3000,
+                timerProgressBar: true,
+                didOpen: (toast) => {
+                    toast.addEventListener('mouseenter', Swal.stopTimer)
+                    toast.addEventListener('mouseleave', Swal.resumeTimer)
+                }
+            })
+
+            Toast.fire({
+                icon: 'success',
+                title: 'The product was added to the cart!'
+            })
+        }
+    }
 
     return (
         <>
-                <div className="product-card">
-                    <div className="badge">New</div>
+            <div className="product-card">
+                <div className="badge">New</div>
+                <Link to={'detail/' + _id}>
                     <div className="product-tumb">
-                        <img src={img} alt=""/>
+                        <img src={img} alt="" />
                     </div>
-                    <div className="product-details">
-                        <span className="product-catagory">MUSIC</span>
-                        <NavLink className="link-product" to={'detail/' + _id}>
+                </Link>
+                <div className="product-details">
+                    <span className="product-catagory">MUSIC</span>
+                    <NavLink className="link-product" to={'detail/' + _id}>
                         <h4><a href="">{name}</a></h4>
-                        </NavLink>
-                        <p><Rating rating={9}/></p>
-                        <div className="product-bottom-details">
-                            <div className="product-price"><small>$ {price + 200 }</small>$ {price}</div>
-                            
-                            <div className="product-links">
+                    </NavLink>
+                    <p><Rating rating={9} /></p>
+                    <div className="product-bottom-details">
+                        <div className="product-price"><small>$ {price + 200}</small>$ {price}</div>
+                        <div className="product-links">
+                        <a className="button-items-delete" onClick={(e) => { handleAddCart(e) }}><FaCartPlus /></a>
                             <NavLink className="link-product" to={'detail/' + _id}>
-                                <a href=""><BsFillEyeFill/></a>
-                                </NavLink>
-                                {/* <a className='buttonfav' onClick={()=>dispatch(addProductFav(objFav))}><AiTwotoneHeart/></a> */}
-                            </div>
+                                <a href=""><BsHeartFill /></a>
+                            </NavLink>
+                            
                         </div>
                     </div>
                 </div>
+            </div>
         </>
     )
 }

--- a/client/src/components/ProductsList/ProductsList.jsx
+++ b/client/src/components/ProductsList/ProductsList.jsx
@@ -94,6 +94,7 @@ export default function ProductsList({ filteredProducts }) {
                 rating={e.rating}
                 _id={e._id}
                 isActive={e.isActive}
+                stock={e.stock}
                 key={keyblablabla}
               />
             );

--- a/client/src/components/itemCart/itemCart.jsx
+++ b/client/src/components/itemCart/itemCart.jsx
@@ -5,6 +5,7 @@ import SetItem from "../setItemCart/SetItem";
 import {AiTwotoneDelete} from "react-icons/ai"
 import './itemCart.css'
 import { Link } from "react-router-dom";
+import Swal from 'sweetalert2'
 
 
 export default function ItemCart({ item }) {
@@ -15,6 +16,22 @@ export default function ItemCart({ item }) {
   const handleRemoveItem = (e) => {
     e.preventDefault();
     dispatch(removeItem(_id));
+    const Toast = Swal.mixin({
+      toast: true,
+      position: 'top-end',
+      showConfirmButton: false,
+      timer: 3000,
+      timerProgressBar: true,
+      didOpen: (toast) => {
+          toast.addEventListener('mouseenter', Swal.stopTimer)
+          toast.addEventListener('mouseleave', Swal.resumeTimer)
+      }
+  })
+
+  Toast.fire({
+      icon: 'warning',
+      title: 'The product was removed to the cart!'
+  })
   };
 
   return (


### PR DESCRIPTION
Hola chicos, adicione el LocalStorage remove para que al hacer logout el localStorage no persista en todas las sesiones del browser.

Desde el card de producto ya se puede ir a detalle en la imagen y nombre, por su parte el carrito ya adiciona. Le adicione dos alerts al adicionar al carrito y el eliminar del carrito. (Hagan npm i en el client cuando bajen los cambios). 

Estoy viendo que debo hacer algo con el localStorage en el home porque ahí no persiste el estado del carrito en las recargas de la página.