### PR TITLE
Fixes de forms

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -22,14 +22,14 @@ import About from './components/FormAbout/FormAbout';
 
 function App() {
   const dispatch = useDispatch()
-  const u = useSelector(state => state.user)
+ /*  const u = useSelector(state => state.user)
   const role = u.user ? u.user[0]?.role : null
-  const {user} = useAuth0();
+  const {user} = useAuth0(); */
 
   useEffect(() => {
     dispatch(getProducts())
-    dispatch(searchUserInDb(user?.email))
-  }, [dispatch, user])
+    /* dispatch(searchUserInDb(user?.email)) */
+  }, [dispatch/* , user */])
 
   return (
     <div className="App">

--- a/client/src/components/QuestionForm/QuestionForm.jsx
+++ b/client/src/components/QuestionForm/QuestionForm.jsx
@@ -26,7 +26,7 @@ export function QuestionForm({productN, productId, nickname, close}){
         e.preventDefault();
         console.log(question.productId, 'productId en handleSubmit');    
         addQuestion({question})
-        window.location.reload();   
+        setTimeout(() => {window.location.reload()}, 300);   
     }
 
     const handleClose = (e) => {

--- a/client/src/components/QuestionsAdminSide/FormAnswerQuestion/FormAnswerQuestion.jsx
+++ b/client/src/components/QuestionsAdminSide/FormAnswerQuestion/FormAnswerQuestion.jsx
@@ -15,7 +15,7 @@ export function FormAnswerQuestion({questA, handleClosePopup}) {
     const handleSubmit = (event) => {
         event.preventDefault();
         axios.post(`${LOCALHOST_URL}/products/questions?product=${question.questionFromProduct}&question=${question.question._id}`, {answer: answer})
-        .then(window.location.reload()) 
+        .then(setTimeout(() => window.location.reload(), 300)) 
 
     }
 

--- a/client/src/components/Users/Users.jsx
+++ b/client/src/components/Users/Users.jsx
@@ -106,7 +106,7 @@ export const Users = () => {
             console.log(idEdit, "idEdit")
             dispatch(makeAdmin(idEdit))
             handleEditSuccess()
-            window.location.reload()
+            setTimeout(() => window.location.reload(), 300)
         }
     }, [successEdit])
 


### PR DESCRIPTION
SOLUCIÓN NO DEFINITIVA.

Funciona a la perfección pero la idea es NO usar el window reload. 
Arreglados los formularios de preguntas y review. También los del lado del admin que tenian window reload y no funcaban. Un setTimeout de 300ms lo arregla por ahora. Saqué la protección de ruta y tenemos que buscar otra forma. Todo andando.

Aclaro que este merge es para el deploy, no para main. Aunque también deberiamos hacerlo.